### PR TITLE
Adding podman dependency for Fedora

### DIFF
--- a/BUILD.md
+++ b/BUILD.md
@@ -25,7 +25,7 @@ Create a .deb:
 Install dependencies:
 
 ```sh
-sudo dnf install -y rpm-build python3 python3-qt5 python3-appdirs python3-click python3-pyxdg python3-requests
+sudo dnf install -y rpm-build python3 python3-qt5 python3-appdirs python3-click python3-pyxdg python3-requests podman
 ```
 
 Run from source tree:

--- a/install/linux/build_rpm.py
+++ b/install/linux/build_rpm.py
@@ -39,7 +39,7 @@ def main():
             "python3",
             "setup.py",
             "bdist_rpm",
-            "--requires=python3-qt5,python3-appdirs,python3-click,python3-pyxdg,python3-requests",
+            "--requires=python3-qt5,python3-appdirs,python3-click,python3-pyxdg,python3-requests,podman",
         ]
     )
 


### PR DESCRIPTION
Fedora 30 requires podman for dangerzone.