### PR TITLE
When finding PDF viewers, skip apps that do not have Info.plist files

### DIFF
--- a/dangerzone/global_common.py
+++ b/dangerzone/global_common.py
@@ -332,6 +332,11 @@ class GlobalCommon(object):
 
                 # Load its plist file
                 plist_path = os.path.join(app_path, "Contents/Info.plist")
+
+                # Skip if there's not an Info.plist
+                if not os.path.exists(plist_path):
+                    continue
+
                 with open(plist_path, "rb") as f:
                     plist_data = f.read()
                 plist_dict = plistlib.loads(plist_data)


### PR DESCRIPTION
Resolves #43 

It turns out in macOS before Catalina, when you run this to find all PDF viewers:

```
bundle_identifiers = LaunchServices.LSCopyAllRoleHandlersForContentType(
    "com.adobe.pdf", CoreServices.kLSRolesAll
)
```

One of the bundle identifiers that gets returned is `com.apple.system-library`, which isn't actually an app bundle. The logic that finds the path of that app bundle ends up finding `/System/Library/Contents/Info.plist` which doesn't exist, so it crashes when trying to open it.

This fix simply makes sure that the `Info.plist` file exists before trying to open it, and it appears to fix the problem.