### PR TITLE
Allow dependency on docker-ce package

### DIFF
--- a/stdeb.cfg
+++ b/stdeb.cfg
@@ -1,6 +1,6 @@
 [DEFAULT]
 Package3: dangerzone
-Depends3: docker.io, python3, python3-pyqt5, python3-appdirs, python3-click, python3-xdg, python3-requests
+Depends3: docker.io | docker-ce, python3, python3-pyqt5, python3-appdirs, python3-click, python3-xdg, python3-requests
 Build-Depends: python3, python3-all
 Suite: bionic
 X-Python3-Version: >= 3.7


### PR DESCRIPTION
This allows dangerzone to be installed by users who install Docker through the docker.com
repositories, which use the `docker-ce` package instead of `docker.io`.

See #60 .