### PR TITLE
Fix for docker_installer.py

### DIFF
--- a/dangerzone/docker_installer.py
+++ b/dangerzone/docker_installer.py
@@ -33,7 +33,7 @@ def is_docker_installed(global_common):
 
 def is_docker_ready(global_common):
     # Run `docker image ls` without an error
-    with global_common.exec_dangerzone_container(["image-ls"]) as p:
+    with global_common.exec_dangerzone_container(["image_ls"]) as p:
         p.communicate()
 
         # The user canceled, or permission denied


### PR DESCRIPTION
The `is_docker_ready` function passes an invalid argument to `exec_dangerzone_container`.  The passed argument contains a dash instead of an underscore.  This creates the logic situation wherein the UI states that Docker is not installed on Linux derivatives and also issues a `Failed to start docker service` command line error.