### PR TITLE
Fix for tasks.py

### DIFF
--- a/dangerzone/tasks.py
+++ b/dangerzone/tasks.py
@@ -72,7 +72,7 @@ class ConvertToPixels(TaskBase):
     def run(self):
         self.update_label.emit("Converting document to pixels")
         args = [
-            "document-to-pixels",
+            "document_to_pixels",
             "--document-filename",
             self.common.document_filename,
             "--pixel-dir",
@@ -173,7 +173,7 @@ class ConvertToPDF(TaskBase):
         ]
 
         args = [
-            "pixels-to-pdf",
+            "pixels_to_pdf",
             "--pixel-dir",
             self.common.pixel_dir.name,
             "--safe-dir",


### PR DESCRIPTION
The `container.py` file has two functions that are incorrectly referenced in `tasks.py`.  These are `document_to_pixels` and `pixels_to_pdf`.  Renaming the args in the `tasks.py` file to appropriately reference those functions.  Without these fixes the software crashes with an error of: `Error: No such command "document-to-pixels"` and `Error: No such command "pixels_to_pdf"`.