### PR TITLE
Check if CFBundleName exist

### DIFF
--- a/dangerzone/global_common.py
+++ b/dangerzone/global_common.py
@@ -369,7 +369,7 @@ class GlobalCommon(object):
                     plist_data = f.read()
                 plist_dict = plistlib.loads(plist_data)
 
-                if plist_dict["CFBundleName"] != "Dangerzone":
+                if plist_dict.get("CFBundleName") and plist_dict["CFBundleName"] != "Dangerzone":
                     pdf_viewers[plist_dict["CFBundleName"]] = bundle_identifier
 
         elif platform.system() == "Linux":


### PR DESCRIPTION
Hello,
this is my take on a potential fix for #74 

This simply skip any app which does not have `CFBundleName` set, and Dangerzone, from being added to `pdf_viewers`.
