### PR TITLE
Container hardening

### DIFF
--- a/dangerzone/container.py
+++ b/dangerzone/container.py
@@ -75,6 +75,7 @@ def documenttopixels(document_filename, pixel_dir, container_name):
                 "run",
                 "--network",
                 "none",
+                "--security-opt=no-new-privileges:true",
                 "-v",
                 f"{document_filename}:/tmp/input_file",
                 "-v",


### PR DESCRIPTION
Resolves #53.

I added `--security-opt=no-new-privileges:true` to the `docker run` subprocess, and it seems to work great.

I also updated the container to be based off of alpine, so it contains far fewer dependencies and no know vulnerabilities: https://github.com/firstlookmedia/dangerzone-converter/pull/8