### PR TITLE
Use getpass.getuser() to determine user login

### DIFF
--- a/dangerzone/container.py
+++ b/dangerzone/container.py
@@ -5,6 +5,7 @@ import sys
 import pipes
 import shutil
 import os
+import getpass
 
 # What is the container runtime for this platform?
 if platform.system() == "Darwin":
@@ -39,7 +40,7 @@ def exec_container(args):
     # In Tails, tell the container runtime to download over Tor
     if (
         platform.system() == "Linux"
-        and os.getlogin() == "amnesia"
+        and getpass.getuser() == "amnesia"
         and os.getuid() == 1000
     ):
         env = os.environ.copy()


### PR DESCRIPTION
I am packaging dangerzone for debian right now and writing a testsuite for the package, which is supposed to run inside a chroot. 
In a debian chroot, the function `os.getlogin()` returns this error and dangerzone-container dies.

```
> /usr/bin/podman pull docker.io/flmcode/dangerzone
Traceback (most recent call last):
  File "/usr/bin/dangerzone-container", line 33, in <module>
    sys.exit(load_entry_point('dangerzone==0.2.1', 'console_scripts', 'dangerzone-container')())
  File "/usr/lib/python3/dist-packages/click/core.py", line 829, in __call__
    return self.main(*args, **kwargs)
  File "/usr/lib/python3/dist-packages/click/core.py", line 782, in main
    rv = self.invoke(ctx)
  File "/usr/lib/python3/dist-packages/click/core.py", line 1259, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/usr/lib/python3/dist-packages/click/core.py", line 1066, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/usr/lib/python3/dist-packages/click/core.py", line 610, in invoke
    return callback(*args, **kwargs)
  File "/usr/lib/python3/dist-packages/dangerzone/container.py", line 83, in pull
    sys.exit(exec_container(["pull", "docker.io/flmcode/dangerzone"]))
  File "/usr/lib/python3/dist-packages/dangerzone/container.py", line 42, in exec_container
    and os.getlogin() == "amnesia"
OSError: [Errno 6] No such device or address
```

The python docs advise to rather use `getpass.getuser()` instead of `os.getlogin()`. This will first check if any of the variables LOGNAME, USER, LNAME or USERNAME is set and will fallback to `pwd.getpwuid(os.getuid())[0]`, and only if that fails also, it will raise an error. [see here](https://docs.python.org/3/library/os.html#os.getlogin)

Using `getpass.getuser()` fixes the issue for me and is IMO the more robust solution